### PR TITLE
Downgrade libsecret

### DIFF
--- a/net.rpdev.OpenTodoList.json
+++ b/net.rpdev.OpenTodoList.json
@@ -24,8 +24,10 @@
             "config-opts": [
                 "-Dmanpage=false",
                 "-Dvapi=false",
-                "-Dgtk_doc=false",
-                "-Dintrospection=false"
+                "-Dgtk_doc=false"
+                
+                /* Only available in newer library versions: */
+                /* "-Dintrospection=false" */
             ],
             "cleanup": [
                 "/bin",

--- a/net.rpdev.OpenTodoList.json
+++ b/net.rpdev.OpenTodoList.json
@@ -18,7 +18,22 @@
         "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [
-        "shared-modules/libsecret/libsecret.json",
+        {
+            "name": "libsecret",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dmanpage=false",
+                "-Dgtk_doc=false",
+                "-Dvapi=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.gnome.org/GNOME/libsecret/-/archive/0.19.1/libsecret-0.19.1.tar.gz",
+                    "sha256": "303c6e8cf3e12534e885b0682cd6130716c6834397b76d3829321b6d83b2389c"
+                }
+            ]
+        },
         {
             "name": "opentodolist",
             "buildsystem": "cmake-ninja",

--- a/net.rpdev.OpenTodoList.json
+++ b/net.rpdev.OpenTodoList.json
@@ -23,8 +23,15 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Dmanpage=false",
+                "-Dvapi=false",
                 "-Dgtk_doc=false",
-                "-Dvapi=false"
+                "-Dintrospection=false"
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/pkgconfig",
+                "/share/man"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This change downgrades libsecret to an older release. The new one coming from the shared modules has a bug which basically makes it unsuable within a Flatpak.